### PR TITLE
Remove invalid $name prop from span element

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -174,7 +174,6 @@ export default function HomePage() {
                 >
                   <span
                       data-loc="src/app/page.tsx:224:120"
-                      $name="page"
                       className="hero-mobile-title"
                       style={{
                         display: 'none',


### PR DESCRIPTION
## Purpose
Fix a runtime error by removing an invalid prop that was causing the application to fail. The user reported an urgent issue that needed immediate resolution.

## Code changes
- Removed the invalid `$name="page"` prop from a span element in `src/app/page.tsx`
- The span element with class `hero-mobile-title` now only contains valid HTML attributes
- This resolves the runtime error that was preventing proper application functionality

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/8f4da2ef764141a9a92b7118692447fd/spark-garden)

👀 [Preview Link](https://8f4da2ef764141a9a92b7118692447fd-spark-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>8f4da2ef764141a9a92b7118692447fd</projectId>-->
<!--<branchName>spark-garden</branchName>-->